### PR TITLE
Detect git repositories created by git worktree

### DIFF
--- a/src/update.py
+++ b/src/update.py
@@ -38,7 +38,7 @@ decode = None
 
 
 def find_git_repos(dirpath, excludes, depth, name_for_parent=1):
-    """Return list of directories containing a `.git` directory
+    """Return list of directories containing a `.git` file or directory
 
     Results matching globbing patterns in `excludes` will be ignored.
 
@@ -53,7 +53,6 @@ def find_git_repos(dirpath, excludes, depth, name_for_parent=1):
     start = time()
 
     cmd = ['find', '-L', dirpath,
-           '-type', 'd',
            '-name', '.git',
            '-maxdepth', str(depth)]
 


### PR DESCRIPTION
Git 1.5 introduces a new feature called worktrees, which are lightweight working directories that share the object database with a real repository.

This feature creates a `.git` file, rather than a directory, e.g:

```
% cat .git
gitdir: /Users/jason/code/scala/.git/worktrees/scala2
```

This commit lets the `reposupdate` command find such repositories.