### PR TITLE
Fix url convert for remote url

### DIFF
--- a/src/repos.py
+++ b/src/repos.py
@@ -135,7 +135,8 @@ def main(wf):
                         ['git', 'config', 'remote.origin.url'],
                         cwd=path
                     )
-                    url = re.sub(r'https://.+@', 'https://', url).strip()
+                    url = re.sub(r'(^.+@)|(^https://)|(^git://)|(.git$)','',url)
+                    url = "https://" + re.sub(r':','/',url).strip()
                     subprocess.call(['open', '-a', a, url])
 
                 else:


### PR DESCRIPTION
I think this remote URL conversion is not working. 
There are several types of remote URL:
1. git://github.com/VitaliyRodnenko/geeknote.git
2. git@github.com:deanishe/alfred-repos.git
3. https://github.com/deanishe/alfred-repos.git

We want to convert everything to a right URL:
https://github.com/deanishe/alfred-repos