### PR TITLE
Change python paths to python2 for MacOS Monterey compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.DS_Store

--- a/src/README.html
+++ b/src/README.html
@@ -674,6 +674,8 @@ html,body,#wrapper{font-size:10pt!important}
 
 <p>For Alfred 3, download <a href="https://github.com/deanishe/alfred-repos/releases/tag/v2.1.2">version 2.1.2</a>, and for Alfred 2, please download <a href="https://github.com/deanishe/alfred-repos/releases/tag/v1.7">version 1.7</a>.</p>
 
+<p><strong>Due to Apple removing Python 2 from MacOS Monterey you need to manually install <a href="https://www.python.org/downloads/release/python-2716/">Python 2</a> for this workflow to work.</strong></p>
+
 <h2>Usage</h2>
 
 <p>This workflow requires some configuration before use. See <a href="#configuration">Configuration</a> for details.</p>

--- a/src/info.plist
+++ b/src/info.plist
@@ -123,7 +123,7 @@
 				<key>runningsubtext</key>
 				<string>Loading list of repos…</string>
 				<key>script</key>
-				<string>/usr/bin/python repos.py search "$1"</string>
+				<string>/usr/local/bin/python2 repos.py search "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -173,7 +173,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>/usr/bin/python repos.py open $appkey "$1"</string>
+				<string>/usr/local/bin/python2 repos.py open $appkey "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -215,7 +215,7 @@ variables={allvars}</string>
 				<key>escaping</key>
 				<integer>127</integer>
 				<key>script</key>
-				<string>/usr/bin/python repos.py settings</string>
+				<string>/usr/local/bin/python2 repos.py settings</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -324,7 +324,7 @@ variables={allvars}</string>
 				<key>escaping</key>
 				<integer>127</integer>
 				<key>script</key>
-				<string>/usr/bin/python repos.py update</string>
+				<string>/usr/local/bin/python2 repos.py update</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>

--- a/src/repos.py
+++ b/src/repos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env /usr/local/bin/python2
 # encoding: utf-8
 #
 # Copyright (c) 2013 deanishe@deanishe.net.
@@ -280,7 +280,7 @@ def do_update():
         int: Exit status.
 
     """
-    run_in_background('update', ['/usr/bin/python', 'update.py'])
+    run_in_background('update', ['/usr/local/bin/python2', 'update.py'])
     return 0
 
 

--- a/src/workflow/background.py
+++ b/src/workflow/background.py
@@ -230,7 +230,7 @@ def run_in_background(name, args, **kwargs):
         _log().debug('[%s] command cached: %s', name, argcache)
 
     # Call this script
-    cmd = ['/usr/bin/python', __file__, name]
+    cmd = ['/usr/local/bin/python2', __file__, name]
     _log().debug('[%s] passing job to background runner: %r', name, cmd)
     retcode = subprocess.call(cmd)
 

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -2330,7 +2330,7 @@ class Workflow(object):
             update_script = os.path.join(os.path.dirname(__file__),
                                          b'update.py')
 
-            cmd = ['/usr/bin/python', update_script, 'check', repo, version]
+            cmd = ['/usr/local/bin/python2', update_script, 'check', repo, version]
 
             if self.prereleases:
                 cmd.append('--prereleases')
@@ -2369,7 +2369,7 @@ class Workflow(object):
         update_script = os.path.join(os.path.dirname(__file__),
                                      b'update.py')
 
-        cmd = ['/usr/bin/python', update_script, 'install', repo, version]
+        cmd = ['/usr/local/bin/python2', update_script, 'install', repo, version]
 
         if self.prereleases:
             cmd.append('--prereleases')


### PR DESCRIPTION
Due to Apple removing Python 2 from MacOS Monterey this workflow didn't work anymore. Until it's refactored for Python 3 this way it can still be easily used.